### PR TITLE
Feature/base html element unique key

### DIFF
--- a/lib/ReactImitation/dom/updateDom.ts
+++ b/lib/ReactImitation/dom/updateDom.ts
@@ -6,6 +6,7 @@ import {
   getVDOM,
   resetAllComponentKeysIndex,
   resetIndexMap,
+  resetNstChildIndexMap,
   setVDOM,
 } from '../vdom/store';
 import { createDOM } from './createDom';
@@ -28,6 +29,7 @@ export function updateDOM(
 ): void {
   resetAllComponentKeysIndex(); // 모든 컴포넌트 키 인덱스를 초기화
   resetIndexMap(); // 상태 인덱스를 초기화
+  resetNstChildIndexMap(); // 자식 인덱스 초기화
   updateElement($parent, nextVDOM, prevVDOM); // 개별 요소 업데이트
   setVDOM(nextVDOM); // 최신 가상 DOM 설정
 }

--- a/lib/ReactImitation/vdom/store.ts
+++ b/lib/ReactImitation/vdom/store.ts
@@ -9,9 +9,20 @@ const componentIndexStore = new WeakMap<Function, number>(); // 동일 컴포넌
 const componentKeys = new Set<Function>(); // WeakMap의 Key추적을 위한 셋
 const parentKeyStack: string[] = []; // 부모 컴포넌트 추적을 위한 스택
 const usedKeys = new Set(); // 고유 키 생성을 위한 사용된 키셋
+const nstChildIndexMap = new Map<string, number>(); // 부모의 몇번 째 자식인지 저장
 let $root: HTMLElement;
 let VDOM: VDOM;
 let createVDOM: () => VDOM;
+
+export function resetNstChildIndexMap() {
+  nstChildIndexMap.clear();
+}
+
+export function incrementNstChildIndexMap(parentKey: string): number {
+  const currentIndex = nstChildIndexMap.get(parentKey) || 0;
+  nstChildIndexMap.set(parentKey, currentIndex + 1);
+  return currentIndex;
+}
 
 export function resetStore(): void {
   stateStore.clear();


### PR DESCRIPTION
# 📗 작업 내용  
#17  기본 HTML 태그에 unique한 key가 자동으로 주입되도록 수정했습니다.

## 작업 사항
### **기본 HTML 태그에도 unique key가 자동으로 주입되도록 수정**: 
  - props.key가 제공되면 해당 key를 사용하고, 제공되지 않으면 부모 key와 자식 인덱스를 조합하여 고유한 key를 자동 생성하는 방식 적용

## 구현 사항
### 부모 key 가져오기: 
 - getParentKey() 함수 사용
### key 처리:
 - 개발자가 props.key를 명시하면 해당 key 사용
 - 명시하지 않으면, 부모 key와 자식 인덱스를 결합하여 고유한 key 자동 생성
### 리렌더링 최적화:
 - key가 변경되면 해당 요소가 리렌더링되어 하위 요소를 판단하지 않아도 되므로 최적화

### **Key의 변경 여부에 따른 리렌더링 최적화**: 
```
import ReactImitation, { useEffect, useState, navigate } from '@ReactImitation';

export const TestPage = () => {
  const [count1, setCount1] = useState(1);
  const [count2, setCount2] = useState(2);
  const [count3, setCount3] = useState(3);

  useEffect(() => {
    console.log('TestPage가 마운트 되었음');
  }, []);

  return (
    <div>
      hi
      <ul>
        <li key={Math.random()}>
          {count1}
          <button onClick={() => setCount1((prev) => prev + 1)}>+</button>
        </li>
        <li key={Math.random()}>
          {count2}
          <button onClick={() => setCount2((prev) => prev + 1)}>+</button>
        </li>
        <li key={Math.random()}>
          {count3}
          <button onClick={() => setCount3((prev) => prev + 1)}>+</button>
        </li>
      </ul>
      <button onClick={() => navigate('/')}>move to HomePage</button>
    </div>
  );
};
```

props의 key부분을 버튼을 통해 state를 증가시켜 리렌더링을 유도하고, Math.random 함수를 통해 매번 랜덤값이 주입되도록 설정 한 후 작동을 확인했습니다. 

<img width="531" alt="image" src="https://github.com/user-attachments/assets/15fd7830-e5d2-4c59-85e2-0f647f1c6568" />

